### PR TITLE
Add spacing below README support button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <a href="https://buymeacoffee.com/cheesewizard">
   <img src="docs/images/buy-me-a-beer-alt-amplifier-v2.png" alt="Buy me a beer" width="240">
 </a>
+<br>
 
 A fork of [RSMods](https://github.com/Lovrom8/RSMods) that adds pitch routing
 to Rocksmith 2014: a **Drop Pedal** that shifts the guitar to the song, and a


### PR DESCRIPTION
## What changed

- Added an explicit line break below the top Buy Me a Beer button.

## Why

GitHub rendered the linked HTML image with almost no bottom margin, leaving the opening README paragraph too close to the button.

## User impact

The project introduction now has clearer visual separation from the support button.

## Validation

- Confirmed the diff contains only the intended one-line README change.
- `git diff --check` passes.
