### PR TITLE
Fix README spacing and Learn & Play wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://buymeacoffee.com/cheesewizard">
   <img src="docs/images/buy-me-a-beer-alt-amplifier-v2.png" alt="Buy me a beer" width="240">
 </a>
-<br>
+<br><br>
 
 A fork of [RSMods](https://github.com/Lovrom8/RSMods) that adds pitch routing
 to Rocksmith 2014: a **Drop Pedal** that shifts the guitar to the song, and a

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ to Rocksmith 2014: a **Drop Pedal** that shifts the guitar to the song, and a
 **Speaker Mode** that shifts the song to the guitar.
 
 `F7` cycles between the two modes and Off. Range is -24 to +24 semitones.
-Supported game versions: Rocksmith 2014 Remastered (September 2022 update),
-fully playable including multiplayer, and the Learn & Play (December 2024)
-update, supported with partial multiplayer functionality currently.
+Supported game versions: Rocksmith 2014 Remastered (September 2022 update) and
+Learn & Play (December 2024 update). Drop Pedal multiplayer is supported on
+both versions.
 
 https://github.com/user-attachments/assets/c8951c94-e760-4830-a8f5-6b383dbb05da
 

--- a/docs/wwise-plugin-internals.md
+++ b/docs/wwise-plugin-internals.md
@@ -484,9 +484,10 @@ that its LP address landed inside note-detection RMS/onset processing and that
 `[EBP+8]` was a sample count, not a cent offset. Both the hook and its offsets
 were removed rather than retained as a fallback.
 
-The reference-builder address is known for Remastered September 2022. The LP
-December 2024 address is unresolved: live writes still keep in-song detection
-correct, but the pre-song tuner does not see the shifted load-time stamp.
+The reference-builder address is known for both supported builds: `0x004DCCB0`
+for Remastered September 2022 and module base + `0x002AD930` for Learn & Play
+December 2024. Both builds therefore apply the shift to the pre-song tuner's
+load-time snapshot as well as in-song note detection.
 
 
 ---


### PR DESCRIPTION
## Summary
- add a visible blank line below the README support button
- state that Drop Pedal multiplayer is supported on both game builds
- correct the stale Learn & Play tuning-reference documentation

## Verification
- GitHub Markdown API preserves the two consecutive line breaks
- repository offsets provide the Learn & Play tuning-reference builder and both per-player pipeline IDs
- `git diff --check` passes