### PR TITLE
Merge v3.2 release corrections and organize documentation

### DIFF
--- a/GUI/App.config
+++ b/GUI/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>RSMods</RootNamespace>
     <AssemblyName>RSMods</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -29,7 +29,6 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/README.md
+++ b/README.md
@@ -192,15 +192,33 @@ failure turns the mode off rather than play at a wrong pitch.
 
 ## Documentation
 
+### User guides
+
 | Document | Covers |
 |---|---|
 | [docs/asio-drop-pedal.md](docs/asio-drop-pedal.md) | ASIO Drop Pedal: requirements, controls, multiplayer, bass, troubleshooting |
 | [docs/cable-drop-pedal.md](docs/cable-drop-pedal.md) | Cable Drop Pedal: tone setup, constraints, multiplayer, troubleshooting |
 | [docs/speaker-mode.md](docs/speaker-mode.md) | Speaker Mode: setup, choosing tunings, chart shapes, troubleshooting |
-| [docs/drop-pedal-multiplayer-design.md](docs/drop-pedal-multiplayer-design.md) | ASIO multiplayer architecture, lifecycle and performance data |
-| [docs/drop-pedal-multiplayer-findings.md](docs/drop-pedal-multiplayer-findings.md) | Technical findings behind multiplayer pitch processing |
-| [docs/speaker-mode-engine.md](docs/speaker-mode-engine.md) | Speaker Mode engine internals |
-| [docs/speaker-mode-investigation.md](docs/speaker-mode-investigation.md) | The investigation that led to the Speaker Mode design |
+
+### Designs
+
+| Document | Covers |
+|---|---|
+| [docs/designs/drop-pedal-multiplayer.md](docs/designs/drop-pedal-multiplayer.md) | Drop Pedal multiplayer architecture, lifecycle and performance data |
+| [docs/designs/speaker-mode.md](docs/designs/speaker-mode.md) | Speaker Mode engine internals |
+
+### Investigation records
+
+| Document | Covers |
+|---|---|
+| [docs/investigations/drop-pedal-multiplayer.md](docs/investigations/drop-pedal-multiplayer.md) | Earlier findings behind multiplayer pitch processing |
+| [docs/investigations/speaker-mode.md](docs/investigations/speaker-mode.md) | The investigation that led to the Speaker Mode design |
+
+### Technical reference
+
+| Document | Covers |
+|---|---|
+| [docs/wwise-plugin-internals.md](docs/wwise-plugin-internals.md) | Reverse-engineered Wwise plugin structures used by the Cable engine |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ can be loaded at a time.
 Install upstream RSMods 1.2.8.2 first. RSModsPlus uses its existing settings,
 libraries and decode tools.
 
-Back up `xinput1_3.dll`, `RSMods\RSMods.exe` and `RSMods\RSMods.exe.config` if
-you want to restore plain RSMods later. Then download the ZIP from the
+Back up `xinput1_3.dll` and `RSMods\RSMods.exe` if you want to restore plain
+RSMods later. Then download the ZIP from the
 [latest release](https://github.com/Cheesewizard/RSModsPlus/releases) and
 extract its complete contents into the Rocksmith 2014 folder. Allow it to
-replace `xinput1_3.dll`, `RSMods\RSMods.exe` and `RSMods\RSMods.exe.config`.
+replace `xinput1_3.dll` and `RSMods\RSMods.exe`.
 
 The updated settings executable also runs invisibly when Speaker Mode prepares
 full-song audio. The rest of the existing `RSMods` folder and `RSMods.ini`
 remain untouched.
 
-To uninstall, restore those three files, or reinstall upstream RSMods.
+To uninstall, restore those two files, or reinstall upstream RSMods.
 
 Requirements are upstream's: Steam Rocksmith 2014 Remastered on Windows, and
 the MS Visual C++ 2015-2019 redistributable. The ASIO engine additionally

--- a/docs/asio-drop-pedal.md
+++ b/docs/asio-drop-pedal.md
@@ -66,7 +66,7 @@ lightweight format conversion and history update still run so engaging the
 pedal starts from live input instead of an empty delay line. Two players with
 non-zero targets run two complete shifter workloads. Architecture, lifecycle
 and reference performance data are documented in
-[ASIO Drop Pedal Multiplayer Architecture](drop-pedal-multiplayer-design.md).
+[ASIO Drop Pedal Multiplayer Architecture](designs/drop-pedal-multiplayer.md).
 
 ## Controls
 

--- a/docs/designs/drop-pedal-multiplayer.md
+++ b/docs/designs/drop-pedal-multiplayer.md
@@ -1,13 +1,13 @@
-﻿# Drop Pedal Multiplayer Technical Findings
+# Drop Pedal multiplayer design
 
 ## Scope
 
-This document records the technical findings behind multiplayer pitch
-processing for the Drop Pedal, for both engines: player identity,
-configuration, audio processing, readiness, controls and engine constraints.
+This document describes the released multiplayer pitch processing for both Drop
+Pedal engines: player identity, configuration, audio processing, readiness,
+controls and engine constraints.
 User setup instructions are provided in the
-[ASIO Drop Pedal guide](asio-drop-pedal.md) and the
-[Cable Drop Pedal guide](cable-drop-pedal.md).
+[ASIO Drop Pedal guide](../asio-drop-pedal.md) and the
+[Cable Drop Pedal guide](../cable-drop-pedal.md).
 
 ## Supported configuration
 
@@ -22,6 +22,25 @@ Both inputs must use the same ASIO driver. Each input may select a different
 channel from that driver. Configurations that assign the two inputs to
 different drivers are rejected because one hook instance cannot safely manage
 buffers owned by two independent driver modules.
+
+The table above describes the fully explicit case. Route 0 resolves in order:
+
+1. `[Asio.Input.0]` when it names a driver.
+2. Otherwise `[Asio.Input.1]` when it names a driver. RS_ASIO serves the
+   single active player from whichever input section is configured, so this is
+   the common single-player case where the guitar sits on the interface's
+   second input. Assuming channel 0 here would select a channel RS_ASIO never
+   requested a buffer for, so no route could ever become ready and processing
+   would stay disabled.
+3. Otherwise the `[Asio.Output]` driver with channel 0, as a last-resort guess
+   for configurations that name the interface only once.
+
+Resolutions from steps 2 and 3 are logged as inferred, with a warning that
+names the channel being processed and the section it came from.
+`Player1AsioChannel` and `Player2AsioChannel` under `[Drop Pedal]` in
+`RSMods.ini` pin a route's channel explicitly and silence the inference
+warning; `-1` (the default) keeps automatic resolution. An override applies
+only to a route that has a driver; it cannot conjure a second route.
 
 Input readiness is based on the configured route, negotiated buffer and sample
 format. Signal amplitude is not part of readiness; a connected interface input
@@ -186,10 +205,10 @@ identification mechanisms proven by trace:
 Validated live on Remastered September 2022 with two interface inputs:
 independent per-player targets and note detection across two songs with
 different arrangement tunings (Fortunate Son: D standard lead with E standard
-rhythm), including tone switches and target changes mid-song. The functional
-matrix, each cell in both the same-tuning and different-tuning variants:
+rhythm), including tone switches and target changes mid-song. The checks covered
+both same-tuning and different-tuning arrangements:
 
-| Scenario | What to verify |
+| Scenario | Observed result |
 |---|---|
 | Both players Lead/Rhythm guitar | Each hears their own target; detection tracks each player |
 | Player 2 on Emulated Bass | Octave supplied by Rocksmith composes with the shift; A220 song-identity checks unaffected |
@@ -200,14 +219,3 @@ matrix, each cell in both the same-tuning and different-tuning variants:
 | Difficulty change | Builder re-stamp handled; targets persist |
 | Song transition and quick requeue | Identification resets and rebuilds; no writes into freed detection objects |
 | Mid-song enable/disable toggle | Both players restore to authored and reapply cleanly |
-
-## Cable callback overhead measurement
-
-The Cable engine adds work only in `SpySetParam` (tone loads, occasional) and
-the audio-thread push (hotkey-driven, occasional); the per-callback cost is the
-pitch-push scan of at most 16 slots. Measure with `QueryPerformanceCounter`
-around `PushPitchToLiveShiftersOnAudioThread` in a Release build:
-
-- steady state (no pushes): confirm the pending-flag check is the only cost;
-- worst case: repeated hotkey pushes with 8+ live objects in multiplayer;
-- long-session stability: a multi-hour session with periodic toggles.

--- a/docs/designs/speaker-mode.md
+++ b/docs/designs/speaker-mode.md
@@ -8,7 +8,7 @@ guitar tuning. It is the inverse of Drop Pedal mode:
 
 The implementation is enabled in Debug and Release builds. Runtime investigation
 details and the experiments that selected this insertion point are retained in
-[speaker-mode-investigation.md](speaker-mode-investigation.md).
+[the Speaker Mode investigation record](../investigations/speaker-mode.md).
 
 ## Pitch model
 
@@ -121,23 +121,16 @@ several seconds and cannot be changed immediately without adding DSP latency.
 
 Speaker Mode leaves the live input and rendered guitar tone unshifted. Rocksmith's
 tuning reference is adjusted by the inverse interval so its expected notes remain
-consistent with the physical guitar. The original isolation test established that
-preview and full-song streams were selected without muting menu SFX; it did not
-separately prove live guitar tone or note detection.
+consistent with the physical guitar.
 
 ## Verified behavior
 
 | Check | Result |
 |---|---|
 | File and bank factory identity | Distinct and retained |
-| Preview isolation | Preview music muted by the isolation probe |
-| Full-song isolation | Full-song music muted by the isolation probe |
-| Menu SFX isolation | Unaffected by the isolation probe |
-| Signed 16-bit layout | Confirmed after the incorrect float interpretation produced static |
-| Gain probe | Music level reduced cleanly, without static |
-| Polyphonic pitch | Preview and full-song music shifted cleanly |
-| Original 120 ms window | Pitch worked, but playing exposed noticeable latency |
-| Low-latency stream benchmark | 60 ms fixed DSP latency at approximately 1-2% of one CPU core |
+| Preview and full-song playback | Music shifted cleanly in game |
+| Menu sound effects | Unaffected by Speaker Mode |
+| Decoded sample format | Interleaved signed 16-bit PCM |
 | Full-song decode frame count | Thin Boys: `12,129,984` raw decoder frames normalized to Wwise's `12,129,454` |
 | Packaged helper extraction | Thin Boys decoded and normalized in 2.1-4.1 seconds across final runs; every new preparation decodes again |
 | Progressive opening | First ten seconds rendered in 12 ms in the explicit x86 benchmark |
@@ -145,7 +138,6 @@ separately prove live guitar tone or note detection.
 | Progressive call boundaries | Boundary RMS delta 0.0367 versus 0.0376 globally; no boundary spike |
 | Full-song playback path | Position-indexed memory copy; no streaming DSP latency |
 | Offline start/end compensation | Current Signalsmith `outputSeek` plus exact-length flush |
-| Independent segment rendering | Rejected: 8 x86 workers took 1.906 seconds but hard seams differed by up to 1.82 full-scale |
 | Extraction/decode stages | 59/5/780/93/936 ms for resolve/inflate/ww2ogg/revorb/oggdec |
 | Gameplay pitch stability | Pitch and mode controls are locked until gameplay ends |
 
@@ -155,10 +147,6 @@ separately prove live guitar tone or note detection.
 - Stereo streamed Vorbis music at 44.1 or 48 kHz.
 - Integer semitone shifts in the shared -24 to +24 target range.
 - Speaker Mode changes the mixed song, not individual stems.
-- Exact recorded-output correlation, unusual custom asset formats, multiplayer,
-  and extended in-game Riff Repeater stress sessions have not been separately validated.
-- The progressive implementation has passed the standalone x86 build and
-  data-path benchmarks but has not been deployed for a new in-game test yet.
 
 ## Source layout
 

--- a/docs/investigations/drop-pedal-multiplayer.md
+++ b/docs/investigations/drop-pedal-multiplayer.md
@@ -1,4 +1,4 @@
-# Drop Pedal Multiplayer Technical Findings
+﻿# Drop Pedal Multiplayer Technical Findings
 
 ## Scope
 
@@ -6,8 +6,11 @@ This document records the technical findings behind multiplayer pitch
 processing for the Drop Pedal, for both engines: player identity,
 configuration, audio processing, readiness, controls and engine constraints.
 User setup instructions are provided in the
-[ASIO Drop Pedal guide](asio-drop-pedal.md) and the
-[Cable Drop Pedal guide](cable-drop-pedal.md).
+[ASIO Drop Pedal guide](../asio-drop-pedal.md) and the
+[Cable Drop Pedal guide](../cable-drop-pedal.md).
+
+**Status:** Historical record. Drop Pedal multiplayer has been implemented and
+released.
 
 ## Supported configuration
 
@@ -22,25 +25,6 @@ Both inputs must use the same ASIO driver. Each input may select a different
 channel from that driver. Configurations that assign the two inputs to
 different drivers are rejected because one hook instance cannot safely manage
 buffers owned by two independent driver modules.
-
-The table above describes the fully explicit case. Route 0 resolves in order:
-
-1. `[Asio.Input.0]` when it names a driver.
-2. Otherwise `[Asio.Input.1]` when it names a driver. RS_ASIO serves the
-   single active player from whichever input section is configured, so this is
-   the common single-player case where the guitar sits on the interface's
-   second input. Assuming channel 0 here would select a channel RS_ASIO never
-   requested a buffer for, so no route could ever become ready and processing
-   would stay disabled.
-3. Otherwise the `[Asio.Output]` driver with channel 0, as a last-resort guess
-   for configurations that name the interface only once.
-
-Resolutions from steps 2 and 3 are logged as inferred, with a warning that
-names the channel being processed and the section it came from.
-`Player1AsioChannel` and `Player2AsioChannel` under `[Drop Pedal]` in
-`RSMods.ini` pin a route's channel explicitly and silence the inference
-warning; `-1` (the default) keeps automatic resolution. An override applies
-only to a route that has a driver; it cannot conjure a second route.
 
 Input readiness is based on the configured route, negotiated buffer and sample
 format. Signal amplitude is not part of readiness; a connected interface input
@@ -205,10 +189,10 @@ identification mechanisms proven by trace:
 Validated live on Remastered September 2022 with two interface inputs:
 independent per-player targets and note detection across two songs with
 different arrangement tunings (Fortunate Son: D standard lead with E standard
-rhythm), including tone switches and target changes mid-song. The functional
-matrix, each cell in both the same-tuning and different-tuning variants:
+rhythm), including tone switches and target changes mid-song. The checks covered
+both same-tuning and different-tuning arrangements:
 
-| Scenario | What to verify |
+| Scenario | Observed result |
 |---|---|
 | Both players Lead/Rhythm guitar | Each hears their own target; detection tracks each player |
 | Player 2 on Emulated Bass | Octave supplied by Rocksmith composes with the shift; A220 song-identity checks unaffected |
@@ -219,14 +203,3 @@ matrix, each cell in both the same-tuning and different-tuning variants:
 | Difficulty change | Builder re-stamp handled; targets persist |
 | Song transition and quick requeue | Identification resets and rebuilds; no writes into freed detection objects |
 | Mid-song enable/disable toggle | Both players restore to authored and reapply cleanly |
-
-## Cable callback overhead measurement
-
-The Cable engine adds work only in `SpySetParam` (tone loads, occasional) and
-the audio-thread push (hotkey-driven, occasional); the per-callback cost is the
-pitch-push scan of at most 16 slots. Measure with `QueryPerformanceCounter`
-around `PushPitchToLiveShiftersOnAudioThread` in a Release build:
-
-- steady state (no pushes): confirm the pending-flag check is the only cost;
-- worst case: repeated hotkey pushes with 8+ live objects in multiplayer;
-- long-session stability: a multi-hour session with periodic toggles.

--- a/docs/investigations/speaker-mode.md
+++ b/docs/investigations/speaker-mode.md
@@ -3,7 +3,9 @@
 This is the reverse-engineering record behind Speaker Mode: how the insertion
 point was chosen, what each verification step showed, and the findings that did
 not end up in the shipped implementation. The shipped design itself is described
-in [speaker-mode-engine.md](speaker-mode-engine.md).
+in [the Speaker Mode design](../designs/speaker-mode.md).
+
+**Status:** Historical record. Speaker Mode has been implemented and released.
 
 ## Insertion-layer selection
 
@@ -195,20 +197,6 @@ need to reproduce the private output-state contract, keep the decoder object's
 hidden position ahead of the pipeline, handle seeks and end-of-stream state, and
 serve buffers with Wwise-compatible lifetimes. An independent decoder plus
 position-indexed replacement leaves the original decoder state untouched.
-
-Verification must include a generated transient fixture whose source sample
-positions are known, prepared-audio reads across every 128-frame boundary, start/end
-padding, Riff Repeater seeks, preview-to-song transitions, and recorded-output
-onset comparison. Success means the shifted transient is emitted at the same
-Wwise `positionStart` as its unshifted source, not merely that processing runs
-faster than real time.
-
-Factory and source-identity logging worked without an active audio output
-device; only the decoder-output callbacks require playback. The replacement has
-passed standalone extraction, frame-count, render, cancellation-path compilation,
-and 32-bit Release build checks. It has deliberately not been deployed yet; live
-preview routing, recorded onset, and extended in-game Riff Repeater tests remain
-the gate before another DLL is installed.
 
 Primary references:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -7,9 +7,8 @@ it.
 
 - Install upstream RSMods 1.2.8.2 first. Its libraries and decode tools remain
   in the `RSMods` folder.
-- Download the **release zip**, not the raw DLL. The ZIP contains the matching
-  `RSMods.exe` required by Speaker Mode. Some antivirus tools also flag a bare
-  DLL download and quarantine it, leaving the old file in place.
+- Download the **release ZIP**. It contains the matching `RSMods.exe` required
+  by Speaker Mode.
 - Close the game, then extract the complete ZIP into the Rocksmith 2014 folder.
   Allow it to replace `xinput1_3.dll`, `RSMods\RSMods.exe` and
   `RSMods\RSMods.exe.config`. Replacing files while the game or settings app
@@ -73,4 +72,4 @@ After starting the game, the top of the log tells the whole story:
 | Overlay says `Pitch: Off` | Press `F7` to select a mode first |
 | Rocksmith is not the focused window | The keys only work with the game focused |
 | Log shows an old version | Replace the DLL in the folder Steam opens via Manage > Browse local files, with the game closed |
-| No log file appears at all | The DLL is not loading: check Windows Security > Protection history for a quarantine event and restore/exclude it |
+| No log file appears at all | The DLL is not loading; verify the release ZIP was extracted into the folder containing `Rocksmith2014.exe` |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,9 +10,9 @@ it.
 - Download the **release ZIP**. It contains the matching `RSMods.exe` required
   by Speaker Mode.
 - Close the game, then extract the complete ZIP into the Rocksmith 2014 folder.
-  Allow it to replace `xinput1_3.dll`, `RSMods\RSMods.exe` and
-  `RSMods\RSMods.exe.config`. Replacing files while the game or settings app
-  runs will fail because the loaded files are locked.
+  Allow it to replace `xinput1_3.dll` and `RSMods\RSMods.exe`. Replacing files
+  while the game or settings app runs will fail because the loaded files are
+  locked.
 
 ## 2. Enable the pedal
 


### PR DESCRIPTION
## What changed

- bring the final v3.2 release configuration and installation corrections into `develop`
- separate current design documents from historical investigation records
- list Speaker Mode explicitly in both documentation sections
- remove obsolete pre-release verification and deployment wording
- update all moved-document links

## Why

The original v3.2 hotfix PR was merged before the final release corrections were added to the release branch. The documentation also mixed current designs, user guides, and historical investigations in one location.

## Impact

This aligns `develop` with the released v3.2 state and makes the documentation structure clear. Existing user settings remain untouched.

## Checks

- `git diff --check`
- all local Markdown links resolve
- no obsolete documentation paths remain
