### PR TITLE
Fix Speaker Mode extraction with malformed PSARC entries

### DIFF
--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -130,6 +130,7 @@
     <Compile Include="GuitarSpeak.cs" />
     <Compile Include="MemoryStream.cs" />
     <Compile Include="Profiles.cs" />
+    <Compile Include="PsarcEntryPath.cs" />
     <Compile Include="Rocksmith\ReadSettings.cs" />
     <Compile Include="Rocksmith\WriteSettings.cs" />
     <Compile Include="SetAndForgetMods.cs" />

--- a/GUI/PsarcEntryPath.cs
+++ b/GUI/PsarcEntryPath.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+
+namespace RSMods
+{
+	internal static class PsarcEntryPath
+	{
+		private const string WEM_EXTENSION = ".wem";
+
+		public static bool TryGetFileName(string entryPath, out string fileName)
+		{
+			if (entryPath == null)
+			{
+				fileName = null;
+				return false;
+			}
+
+			var separatorIndex = Math.Max(entryPath.LastIndexOf('/'), entryPath.LastIndexOf('\\'));
+			fileName = entryPath.Substring(separatorIndex + 1);
+			return true;
+		}
+
+		public static bool TryGetWemMediaId(string entryPath, out uint mediaId)
+		{
+			if (!TryGetFileName(entryPath, out string fileName)
+				|| !fileName.EndsWith(WEM_EXTENSION, StringComparison.OrdinalIgnoreCase))
+			{
+				mediaId = 0;
+				return false;
+			}
+
+			var name = fileName.Substring(0, fileName.Length - WEM_EXTENSION.Length);
+			return uint.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out mediaId);
+		}
+	}
+}

--- a/GUI/SpeakerModeCacheExtractor.cs
+++ b/GUI/SpeakerModeCacheExtractor.cs
@@ -2,7 +2,6 @@ using Rocksmith2014PsarcLib.Psarc;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -240,7 +239,11 @@ namespace RSMods
 				using (var archive = new PsarcFile(archivePath))
 				{
 					var bankEntry = archive.TOC.Entries.FirstOrDefault(entry =>
-						string.Equals(Path.GetFileName(entry.Path), bankName, StringComparison.OrdinalIgnoreCase));
+						PsarcEntryPath.TryGetFileName(entry.Path, out string entryFileName)
+						&& string.Equals(
+							entryFileName,
+							bankName,
+							StringComparison.OrdinalIgnoreCase));
 					if (bankEntry == null)
 					{
 						continue;
@@ -255,14 +258,12 @@ namespace RSMods
 
 					var matchingWems = archive.TOC.Entries.Where(entry =>
 					{
-						if (!string.Equals(Path.GetExtension(entry.Path), ".wem", StringComparison.OrdinalIgnoreCase))
+						if (!PsarcEntryPath.TryGetWemMediaId(entry.Path, out uint mediaId))
 						{
 							return false;
 						}
 
-						var name = Path.GetFileNameWithoutExtension(entry.Path);
-						return uint.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out uint mediaId)
-							&& Contains(bankBytes, BitConverter.GetBytes(mediaId));
+						return Contains(bankBytes, BitConverter.GetBytes(mediaId));
 					}).ToList();
 
 					if (matchingWems.Count != 1)

--- a/Tests/ShifterHarness/README.md
+++ b/Tests/ShifterHarness/README.md
@@ -46,6 +46,9 @@ It verifies frame counts, deterministic output, mapped-output accuracy, and
 continuity across streaming call boundaries.
 
 `speaker_extractor_benchmark.cs` isolates PSARC discovery, WEM extraction, and
-the external decode stages. Build it beside `GUI\Lib\Rocksmith2014PsarcLib.dll`.
+the external decode stages. Compile it with `GUI\PsarcEntryPath.cs` beside
+`GUI\Lib\Rocksmith2014PsarcLib.dll`.
 `speaker_extractor_integration_test.cs` drives the same command-line extraction
-entry point exposed by `RSMods.exe`.
+entry point exposed by `RSMods.exe`. Its `--test-psarc-entry-paths` mode verifies
+that PSARC entry names are parsed as archive identifiers, including names with
+characters Windows rejects in filesystem paths and pathless TOC entries.

--- a/Tests/ShifterHarness/speaker_extractor_benchmark.cs
+++ b/Tests/ShifterHarness/speaker_extractor_benchmark.cs
@@ -2,7 +2,6 @@ using Rocksmith2014PsarcLib.Psarc;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -82,7 +81,11 @@ namespace RSMods.Tests.ShifterHarness
 				using (var archive = new PsarcFile(archivePath))
 				{
 					var bankEntry = archive.TOC.Entries.FirstOrDefault(entry =>
-						string.Equals(Path.GetFileName(entry.Path), bankName, StringComparison.OrdinalIgnoreCase));
+						RSMods.PsarcEntryPath.TryGetFileName(entry.Path, out string entryFileName)
+						&& string.Equals(
+							entryFileName,
+							bankName,
+							StringComparison.OrdinalIgnoreCase));
 					if (bankEntry == null)
 					{
 						continue;
@@ -97,14 +100,12 @@ namespace RSMods.Tests.ShifterHarness
 
 					var matchingWems = archive.TOC.Entries.Where(entry =>
 					{
-						if (!string.Equals(Path.GetExtension(entry.Path), ".wem", StringComparison.OrdinalIgnoreCase))
+						if (!RSMods.PsarcEntryPath.TryGetWemMediaId(entry.Path, out uint mediaId))
 						{
 							return false;
 						}
 
-						var name = Path.GetFileNameWithoutExtension(entry.Path);
-						return uint.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out uint mediaId)
-							&& Contains(bankBytes, BitConverter.GetBytes(mediaId));
+						return Contains(bankBytes, BitConverter.GetBytes(mediaId));
 					}).ToList();
 					if (matchingWems.Count != 1)
 					{

--- a/Tests/ShifterHarness/speaker_extractor_integration_test.cs
+++ b/Tests/ShifterHarness/speaker_extractor_integration_test.cs
@@ -4,8 +4,15 @@ namespace RSMods
 {
 	internal static class SpeakerExtractorIntegrationTest
 	{
+		private const string PATH_TEST_ARGUMENT = "--test-psarc-entry-paths";
+
 		private static int Main(string[] arguments)
 		{
+			if (arguments.Length == 1 && string.Equals(arguments[0], PATH_TEST_ARGUMENT, StringComparison.Ordinal))
+			{
+				return RunPathTests();
+			}
+
 			if (!SpeakerModeCacheExtractor.TryRun(arguments, out int exitCode))
 			{
 				Console.Error.WriteLine("Speaker Mode extractor rejected its command line.");
@@ -13,6 +20,81 @@ namespace RSMods
 			}
 
 			return exitCode;
+		}
+
+		private static int RunPathTests()
+		{
+			try
+			{
+				AssertFileName("songs/bin/generic/Song_Savior.bnk", "Song_Savior.bnk");
+				AssertFileName("songs\\bin\\generic\\Song_Savior.bnk", "Song_Savior.bnk");
+				AssertFileName("manifests/songs/invalid\0entry", "invalid\0entry");
+				AssertNotFileName(null);
+
+				AssertMediaId("audio/windows/123456789.wem", 123456789);
+				AssertMediaId("audio\\windows\\42.WEM", 42);
+				AssertNotMediaId(null);
+				AssertNotMediaId("manifests/songs/invalid\0entry");
+				AssertNotMediaId("audio/windows/not-a-number.wem");
+
+				Console.WriteLine("Speaker extractor PSARC entry path tests passed.");
+				return 0;
+			}
+			catch (Exception exception)
+			{
+				Console.Error.WriteLine(exception);
+				return 1;
+			}
+		}
+
+		private static void AssertFileName(string entryPath, string expectedFileName)
+		{
+			if (!PsarcEntryPath.TryGetFileName(entryPath, out string actualFileName))
+			{
+				throw new InvalidOperationException($"Expected a file name for '{entryPath}'.");
+			}
+
+			AssertEqual(expectedFileName, actualFileName);
+		}
+
+		private static void AssertNotFileName(string entryPath)
+		{
+			if (PsarcEntryPath.TryGetFileName(entryPath, out string fileName))
+			{
+				throw new InvalidOperationException(
+					$"Expected no file name for '{entryPath}', got '{fileName}'.");
+			}
+		}
+
+		private static void AssertMediaId(string entryPath, uint expectedMediaId)
+		{
+			if (!PsarcEntryPath.TryGetWemMediaId(entryPath, out uint actualMediaId))
+			{
+				throw new InvalidOperationException($"Expected a WEM media ID for '{entryPath}'.");
+			}
+
+			if (actualMediaId != expectedMediaId)
+			{
+				throw new InvalidOperationException(
+					$"Expected media ID {expectedMediaId} for '{entryPath}', got {actualMediaId}.");
+			}
+		}
+
+		private static void AssertNotMediaId(string entryPath)
+		{
+			if (PsarcEntryPath.TryGetWemMediaId(entryPath, out uint mediaId))
+			{
+				throw new InvalidOperationException(
+					$"Expected no WEM media ID for '{entryPath}', got {mediaId}.");
+			}
+		}
+
+		private static void AssertEqual(string expected, string actual)
+		{
+			if (!string.Equals(expected, actual, StringComparison.Ordinal))
+			{
+				throw new InvalidOperationException($"Expected '{expected}', got '{actual}'.");
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What changed

- Parse PSARC entry names as archive identifiers instead of Windows filesystem paths.
- Continue past pathless TOC records while searching for the selected song bank and WEM.
- Add focused regression coverage for invalid Windows path characters and null TOC paths.

## Root cause

The full-song Speaker Mode extractor scanned every installed PSARC with `System.IO.Path`. A nonstandard entry name could be rejected by Windows path validation, and a pathless TOC record caused `ArgumentNullException`, aborting preparation before the selected song was reached. Song previews still worked because they use the separate live streaming shifter.

## Validation

- Focused PSARC entry-path regression passed, including null bank/WEM paths.
- Release `RSMods.exe` build succeeded.
- Production extraction and decode of `Song_DragThro.bnk` completed with exit code 0 and produced the expected 86,912,876-byte WAV.
- Affected-user runtime validation by Leila Elysee confirmed full-song E to C# (-3) playback was in tune with a C# bass and Rocksmith note detection remained correct.

No DLL code changed.
